### PR TITLE
chore: Remove upstream dockerfile directive

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,3 @@
-# syntax=docker/dockerfile-upstream:master
 ARG CNPG_TAG
 
 FROM ghcr.io/cloudnative-pg/postgresql:$CNPG_TAG

--- a/README.md
+++ b/README.md
@@ -27,3 +27,8 @@ Container images for [cloudnative-pg](https://cloudnative-pg.io/) with the [pgve
 >       postInitSQL:
 >         - ALTER SYSTEM SET search_path TO "$user", public, vectors;
 >         - CREATE EXTENSION IF NOT EXISTS "vectors";
+
+## Building
+
+To build the Dockerfile locally, you need to pass the `CNPG_TAG` and `PGVECTORS_TAG` args. For example:  
+`docker build . --build-arg="CNPG_TAG=16.3" --build-arg="PGVECTORS_TAG=v0.2.1"`


### PR DESCRIPTION
The arg substitution syntax we use has now made it into the default dockerfile syntax